### PR TITLE
Fix name:Constructor style props turns in 'unknown' type

### DIFF
--- a/example/src/components/BaseBlank.vue
+++ b/example/src/components/BaseBlank.vue
@@ -1,3 +1,11 @@
+<script>
+export default {
+  props: {
+    hidden: Boolean
+  }
+}
+</script>
+
 <template>
   <br/>
 </template>

--- a/src/getPropsInfoList.ts
+++ b/src/getPropsInfoList.ts
@@ -17,6 +17,17 @@ function getPropsInfoList(component: RuntimeComponentOptions): PropInfo[] {
   return Object.keys(props).map(name => {
     const prop = (props as any)[name]
 
+    // If there are no props defined in Object sytle,
+    // Vue does not convert "prop: Constructor" into Object style.
+    if (typeof prop === 'function') {
+      return {
+        name,
+        type: constructorToString(prop),
+        required: false,
+        default: undefined
+      }
+    }
+
     return {
       name,
       type: constructorToString(prop.type),

--- a/src/getPropsInfoList.ts
+++ b/src/getPropsInfoList.ts
@@ -18,7 +18,7 @@ function getPropsInfoList(component: RuntimeComponentOptions): PropInfo[] {
     const prop = (props as any)[name]
 
     // If there are no props defined in Object sytle,
-    // Vue does not convert "prop: Constructor" into Object style.
+    // Vue does not convert "prop: Constructor" into Object style (See #3).
     if (typeof prop === 'function') {
       return {
         name,


### PR DESCRIPTION
See #3 

---

# Problem

Vue convert `propName: Constructor` style property into `propName: { type: Constructor }` at runtime when there are other properties that was defined in Object style.
But if there are none of them, it doesn't convert `propName:Constructor`.

Since this addon expects all props are converted into Object style, it tries to read `(Constructor).type === undefined` and shows `unknown` for prop type.