### PR TITLE
Changes header and preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,22 @@
       "integrity": "sha512-RisaZmcmCLjRipAY7nVi3fmkIk4Z0JMn8YHdGF6qYMsIDpD0dfzz+3yy2dL5Q5aHWOnqPx51IRxkA44myknJvw==",
       "dev": true
     },
+    "@types/storybook__vue": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/storybook__vue/-/storybook__vue-3.3.0.tgz",
+      "integrity": "sha512-0/0/3P86Tm97nulORTQKFtYkYphhZ8OCYdEIAywp+oGV/CexJxGLffc43EPBrqbT9cP6G9Lz6ELtFobzPAHBig==",
+      "dev": true,
+      "requires": {
+        "@types/webpack-env": "1.13.6",
+        "vue": "2.5.16"
+      }
+    },
+    "@types/webpack-env": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.6.tgz",
+      "integrity": "sha512-5Th3OsZ4gTRdr9Mho83BQ23cex4sRhOR4XTG+m+cJc0FhtUBK9Vn62hBJ+pnQYnSxoPOsKoAPOx6FcphxBC8ng==",
+      "dev": true
+    },
     "@vue/component-compiler": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@vue/component-compiler/-/component-compiler-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/pocka/storybook-addon-vue-info#readme",
   "devDependencies": {
+    "@types/storybook__vue": "^3.3.0",
     "rollup": "^0.58.2",
     "rollup-plugin-typescript2": "^0.13.0",
     "rollup-plugin-vue": "^4.0.2",

--- a/src/components/InfoView.vue
+++ b/src/components/InfoView.vue
@@ -43,6 +43,7 @@ export default {
   >
     <div
       v-if="showHeader"
+      class="header"
       :style="userStyle.header ? userStyle.header.body : {}"
     >
       <h1
@@ -59,25 +60,23 @@ export default {
       </h2>
     </div>
 
-    <template v-if="showSource">
-      <h2 :style="userStyle.source ? userStyle.source.h1 : {}">Usage</h2>
-      <pre class="code"><code>{{template}}</code></pre>
-    </template>
-
-    <h2>Preview</h2>
     <div
       class="component-area"
       :style="userStyle.infoContent"
     >
       <slot></slot>
     </div>
-
     <p
       v-if="summary"
       class="summary"
     >
       {{summary}}
     </p>
+
+    <template v-if="showSource">
+      <h2 :style="userStyle.source ? userStyle.source.h1 : {}">Usage</h2>
+      <pre class="code"><code>{{template}}</code></pre>
+    </template>
 
     <h2 :style="userStyle.propTableHead">Props</h2>
     <table class="props">
@@ -120,6 +119,10 @@ h2 {
   margin-top: 2em;
 }
 
+.header {
+  border-bottom: 1px solid #ccc;
+}
+
 .title {
   margin-bottom: 0;
 }
@@ -148,9 +151,8 @@ h2 {
 }
 
 .component-area {
-  padding: 1em;
-  border: 1px solid #ccc;
-  border-radius: 3px;
+  margin-top: 2em;
+  margin-bottom: 2em;
 }
 
 .props {

--- a/src/components/InfoView.vue
+++ b/src/components/InfoView.vue
@@ -1,7 +1,11 @@
 <script>
 export default {
   props: {
-    name: {
+    storyKind: {
+      type: String,
+      required: true
+    },
+    storyTitle: {
       type: String,
       required: true
     },
@@ -37,19 +41,22 @@ export default {
     class="vue-info"
     :style="userStyle.info"
   >
-    <h1
-      class="title"
-      v-if="showHeader"
-      :style="userStyle.header ? userStyle.header.h1 : {}"
-    >
-      {{name}}
-    </h1>
     <div
-      v-if="summary"
-      class="summary"
-      :style="userStyle.infoContent"
+      v-if="showHeader"
+      :style="userStyle.header ? userStyle.header.body : {}"
     >
-      {{summary}}
+      <h1
+        class="title"
+        :style="userStyle.header ? userStyle.header.h1 : {}"
+      >
+        {{storyKind}}
+      </h1>
+      <h2
+        class="story-title"
+        :style="userStyle.header ? userStyle.header.h2 : {}"
+      >
+        {{storyTitle}}
+      </h2>
     </div>
 
     <template v-if="showSource">
@@ -58,9 +65,19 @@ export default {
     </template>
 
     <h2>Preview</h2>
-    <div class="component-area">
+    <div
+      class="component-area"
+      :style="userStyle.infoContent"
+    >
       <slot></slot>
     </div>
+
+    <p
+      v-if="summary"
+      class="summary"
+    >
+      {{summary}}
+    </p>
 
     <h2 :style="userStyle.propTableHead">Props</h2>
     <table class="props">
@@ -101,6 +118,21 @@ h6 {
 
 h2 {
   margin-top: 2em;
+}
+
+.title {
+  margin-bottom: 0;
+}
+
+.story-title {
+  color: #555;
+  margin-top: 0.5em;
+  font-weight: normal;
+  font-size: 1.2em;
+}
+
+.summary {
+  color: #777;
 }
 
 .summary {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import Vue, { ComponentOptions, PropOptions } from 'vue'
 
+import { Addon, StoryDecorator } from '@storybook/vue'
+
 import { RuntimeComponentOptions } from './types/VueRuntime'
 
 import getPropsInfoList from './getPropsInfoList'
@@ -20,8 +22,10 @@ export { default as withInfo } from './withInfo'
  *     template: '<my-awesome-component :value="0"/>'
  *   }))
  */
-const VueInfoAddon = (storyFn: () => RuntimeComponentOptions) =>
-  withInfo({})(storyFn)()
+const VueInfoAddon: StoryDecorator = (
+  storyFn: () => RuntimeComponentOptions,
+  context
+) => withInfo({})(storyFn)(context)
 
 export default VueInfoAddon
 

--- a/src/options/InfoAddonOptions.ts
+++ b/src/options/InfoAddonOptions.ts
@@ -30,6 +30,8 @@ interface VueInfoAddonOptions {
     infoContent?: InlineStyle
     header?: {
       h1?: InlineStyle
+      h2?: InlineStyle
+      body?: InlineStyle
     }
     source?: {
       h1?: InlineStyle

--- a/src/withInfo/index.ts
+++ b/src/withInfo/index.ts
@@ -1,5 +1,7 @@
 import Vue, { ComponentOptions } from 'vue'
 
+import { Story, StoryDecorator } from '@storybook/vue'
+
 import { defaultOptions, InfoAddonOptions } from '../options'
 import { RuntimeComponentOptions } from '../types/VueRuntime'
 
@@ -9,7 +11,9 @@ import parseStoryComponent from '../parseStoryComponent'
 import InfoView from '../components/InfoView.vue'
 
 export type StoryFactory = () => RuntimeComponentOptions
-export type WithInfo = (story: StoryFactory) => () => ComponentOptions<Vue>
+export type WithInfo = (
+  story: StoryFactory
+) => (context?: { kind: string; story: string }) => ComponentOptions<Vue>
 
 function withInfo(options: Partial<InfoAddonOptions>): WithInfo
 function withInfo(summary: string): WithInfo
@@ -18,7 +22,7 @@ function withInfo(summary: string): WithInfo
  * Displays Component information
  */
 function withInfo(options: Partial<InfoAddonOptions> | string): WithInfo {
-  return storyFn => () => {
+  return storyFn => (context = { kind: '', story: '' }) => {
     const opts = {
       ...defaultOptions,
       ...(typeof options === 'string' ? { summary: options } : options)
@@ -34,7 +38,8 @@ function withInfo(options: Partial<InfoAddonOptions> | string): WithInfo {
       render(h) {
         return h(InfoView, {
           props: {
-            name: componentInfo.name,
+            storyKind: context.kind,
+            storyTitle: context.story,
             summary: opts.summary,
             template: story.template,
             propsList,


### PR DESCRIPTION
* Shows `context.kind` and `context.story` for header (previous: component name and summary)
* Swap preview area and usage section
* Shows summary in preview area

Close #18 