### PR TITLE
Do not break when passing JSX component

### DIFF
--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,0 +1,6 @@
+{
+    "plugins": [
+      "transform-vue-jsx"
+    ]
+
+}

--- a/example/package.json
+++ b/example/package.json
@@ -26,6 +26,8 @@
   "devDependencies": {
     "@storybook/vue": "^3.2.17",
     "babel-core": "^6.26.3",
+    "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-plugin-transform-vue-jsx": "^3.7.0",
     "vue-loader": "^13.5.0",
     "vue-template-compiler": "^2.5.9",
     "webpack": "^3.9.1",

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -150,6 +150,14 @@ storiesOf('withInfo API', module)
       }
     }))
   )
+  .add(
+    'JSX story(2)',
+    withInfo('And you can use PascalCase tag')(() => ({
+      render(h) {
+        return <BaseButton label="works fine!" />
+      }
+    }))
+  )
 
 storiesOf('BaseBlank', module)
   .addDecorator(VueInfoAddon)

--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -142,6 +142,14 @@ storiesOf('withInfo API', module)
       template: '<base-button label="See description"/>'
     }))
   )
+  .add(
+    'JSX story',
+    withInfo('You can also use JSX stories!')(() => ({
+      render(h) {
+        return <base-button label="written in JSX" />
+      }
+    }))
+  )
 
 storiesOf('BaseBlank', module)
   .addDecorator(VueInfoAddon)

--- a/src/parseStoryComponent.ts
+++ b/src/parseStoryComponent.ts
@@ -1,8 +1,11 @@
+import Vue, { CreateElement, RenderContext, VueConstructor } from 'vue'
+
 import { RuntimeComponents, RuntimeComponentOptions } from './types/VueRuntime'
 import ComponentInfo from './types/ComponentInfo'
 
 import hyphenate from './utils/hyphenate'
 import getOutermostTagName from './utils/getOutermostTagName'
+import getOutermostJSXTagName from './utils/getOutermostJSXTagName'
 
 import lookupComponent from './lookupComponent'
 
@@ -12,13 +15,15 @@ import lookupComponent from './lookupComponent'
  */
 function parseStoryComponent(story: RuntimeComponentOptions): ComponentInfo {
   // We need template for display "Usage".
-  if (!story.template) {
+  if (!story.template && !story.render) {
     throw new Error(
-      '`template` must be on component options, but got undefined.'
+      '`template` or `render` must be on component options, but got undefined.'
     )
   }
 
-  const outermostTagName = hyphenate(getOutermostTagName(story.template))
+  const outermostTagName = story.template
+    ? hyphenate(getOutermostTagName(story.template))
+    : getOutermostJSXTagName(story.render!)
 
   // If component was not declared in `components` prop,
   // assume it was registered globally.

--- a/src/utils/getOutermostJSXTagName.spec.ts
+++ b/src/utils/getOutermostJSXTagName.spec.ts
@@ -1,0 +1,7 @@
+import getOutermostJSXTagName from './getOutermostJSXTagName'
+
+it('Should returns outermost tag name', () => {
+  expect(getOutermostJSXTagName(h => h('div'))).toBe('div')
+
+  expect(getOutermostJSXTagName(h => h('div', [h('span')]))).toBe('div')
+})

--- a/src/utils/getOutermostJSXTagName.ts
+++ b/src/utils/getOutermostJSXTagName.ts
@@ -1,0 +1,26 @@
+/**
+ * Returns outermost tag name in JSX.
+ * @param render
+ */
+const getOutermostJSXTagName = (
+  render: (
+    h: (tag: any, dataObject?: any, children?: any[] | string) => any,
+    hack: any
+  ) => any
+): string =>
+  render((tag, dataObject, _children) => {
+    switch (typeof tag) {
+      case 'string':
+        return tag
+      case 'object':
+        if (tag.name) {
+          return tag.name
+        }
+
+        return 'Anonymous'
+      default:
+        return ''
+    }
+  }, {})
+
+export default getOutermostJSXTagName

--- a/src/withInfo/index.ts
+++ b/src/withInfo/index.ts
@@ -49,6 +49,12 @@ function withInfo(options: Partial<InfoAddonOptions> | string): WithInfo {
 
     const story = storyFn()
 
+    if (!story.template && story.render) {
+      console.warn(
+        'This plugins does not support showing story source when using render method.'
+      )
+    }
+
     // Components shown in props tables
     const propTablesComponents = opts.propTables
       ? opts.propTables.map(
@@ -99,7 +105,10 @@ function withInfo(options: Partial<InfoAddonOptions> | string): WithInfo {
             storyKind: context.kind,
             storyTitle: context.story,
             summary: marked(dedent(opts.summary)),
-            template: dedent(story.template || ''),
+            template: dedent(
+              story.template ||
+                '<!-- Sorry, story source for "render" is not supported. -->'
+            ),
             componentDetails,
             showHeader: opts.header,
             showSource: opts.source,


### PR DESCRIPTION
* Fix addon throws an exception when passing story that has render method instead of template.
* Rendering story source is not supported.

See: #36 