### PR TITLE
Partial support for story with render function

### DIFF
--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -154,7 +154,7 @@ storiesOf('withInfo API', module)
     'JSX story(2)',
     withInfo('And you can use PascalCase tag')(() => ({
       render(h) {
-        return <BaseButton label="works fine!" />
+        return <BaseButton style={{ fontSize: '2em' }} label="Okay." />
       }
     }))
   )

--- a/src/components/InfoView.vue
+++ b/src/components/InfoView.vue
@@ -30,6 +30,11 @@ export default {
       type: String,
       required: true
     },
+    /** Language for highlighting story source */
+    lang: {
+      type: String,
+      required: true
+    },
     componentDetails: {
       type: Array,
       default: () => []
@@ -78,6 +83,7 @@ export default {
       v-if="showSource"
       :user-style="userStyle.source"
       :source="template"
+      :lang="lang"
     />
 
     <section-title :style="userStyle.propTableHead">Props</section-title>

--- a/src/components/StorySource.vue
+++ b/src/components/StorySource.vue
@@ -14,6 +14,16 @@ export default {
     source: {
       type: String,
       required: true
+    },
+    lang: {
+      type: String,
+      required: true
+    }
+  },
+  computed: {
+    sourceCode() {
+      // Append ; for jsx to enable syntax highlighting
+      return this.lang === 'jsx' ? `;${this.source}` : this.source
     }
   },
   methods: {
@@ -23,7 +33,7 @@ export default {
       }
 
       hljs.highlightBlock(this.$refs.code, {
-        languages: ['html', 'javascript']
+        languages: [this.lang]
       })
     }
   },
@@ -41,12 +51,11 @@ export default {
 <template>
   <div>
     <section-title :style="userStyle.h1">Story Source</section-title>
-    <pre ref="code" class="code html"><code>{{source}}</code></pre>
+    <pre ref="code" class="code" :class="lang"><code>{{sourceCode}}</code></pre>
   </div>
 </template>
 
 <style src="../../node_modules/highlight.js/styles/github.css">
-
 </style>
 
 <style scoped>

--- a/src/utils/getJSXFromRenderFn.spec.ts
+++ b/src/utils/getJSXFromRenderFn.spec.ts
@@ -1,0 +1,59 @@
+import Vue, { CreateElement } from 'vue'
+
+import getJSXFromRenderFn, { CreateJSX } from './getJSXFromRenderFn'
+
+it('First argument for createElement will be tag name', () => {
+  expect(getJSXFromRenderFn(h => h('div'))).toBe('<div/>')
+
+  const MyButton = Vue.component('my-button', {
+    template: '<button>foo</button>'
+  })
+
+  expect(getJSXFromRenderFn(h => h(MyButton))).toBe('<my-button/>')
+})
+
+it('Anonymous component will be shown as <Anonymous/>', () => {
+  const MyLabel = Vue.extend({
+    template: '<label/>'
+  })
+
+  expect(getJSXFromRenderFn(h => h(MyLabel))).toBe('<Anonymous/>')
+
+  expect(getJSXFromRenderFn(h => h(MyLabel, [h(MyLabel)]))).toBe(
+    '<Anonymous><Anonymous/></Anonymous>'
+  )
+})
+
+it('Renders children', () => {
+  const render = (h: CreateJSX) => h('div', [h('span', [h('a')])])
+
+  expect(getJSXFromRenderFn(render)).toBe('<div><span><a/></span></div>')
+})
+
+it('Renderes text node', () => {
+  expect(getJSXFromRenderFn(h => 'foo')).toBe('foo')
+
+  expect(getJSXFromRenderFn(h => h('p', ['foo']))).toBe('<p>foo</p>')
+})
+
+it('Renderes attributes and props', () => {
+  const bar = false
+
+  const render = (h: CreateJSX) =>
+    h('div', {
+      props: {
+        foo: 'foo',
+        bar
+      },
+      attrs: {
+        label: 'baz'
+      },
+      on: {
+        click: (ev: any) => console.log(ev)
+      }
+    })
+
+  expect(getJSXFromRenderFn(render)).toBe(
+    '<div foo="foo" bar={false} label="baz" onClick={function (ev) {return console.log(ev);}}/>'
+  )
+})

--- a/src/utils/getJSXFromRenderFn.ts
+++ b/src/utils/getJSXFromRenderFn.ts
@@ -1,0 +1,122 @@
+import Vue, {
+  RenderContext,
+  Component,
+  AsyncComponent,
+  VNodeData,
+  ComponentOptions,
+  PropOptions
+} from 'vue'
+
+import { RuntimeComponent } from '../types/VueRuntime'
+
+export type RenderFn = (h: CreateJSX) => any
+
+/**
+ * Get JSX strings from render function.
+ * @param render
+ */
+const getJSXFromRenderFn = (render: RenderFn): string => {
+  return render(createJSX)
+}
+
+export default getJSXFromRenderFn
+
+export interface CreateJSX {
+  (tag?: Tag, children?: JSXStringChildren): string
+  (tag?: Tag, data?: VNodeData, children?: JSXStringChildren): string
+}
+
+function createJSX(tag?: Tag, children?: JSXStringChildren): string
+function createJSX(
+  tag?: Tag,
+  data?: VNodeData,
+  children?: JSXStringChildren
+): string
+
+/**
+ * Custom renderer building JSX strings.
+ */
+function createJSX(
+  tag?: Tag,
+  childrenOrData?: VNodeData | JSXStringChildren,
+  _children?: JSXStringChildren
+): string {
+  const data = (childrenOrData instanceof Array ? {} : childrenOrData) || {}
+  const children =
+    (childrenOrData instanceof Array ? childrenOrData : _children) || []
+
+  const tagName = getTagName(tag)
+
+  const props = formatDataObject(data)
+
+  return children.length
+    ? `<${tagName}${props ? ' ' + props : ''}>${children.join('')}</${tagName}>`
+    : `<${tagName}${props ? ' ' + props : ''}/>`
+}
+
+export type JSXStringChildren = string[]
+export type Tag =
+  | string
+  | Component<any, any, any, any>
+  | AsyncComponent<any, any, any, any>
+  | (() => Component)
+  | undefined
+
+/** Tag name for components that have no name on runtime */
+const Anonymous = 'Anonymous'
+
+/**
+ * Get tag name from 1st argument for h (createJSX).
+ * @param tag
+ */
+const getTagName = (tag: Tag) => {
+  if (!tag) {
+    return Anonymous
+  } else if (typeof tag === 'string') {
+    return tag
+  } else if (tag.name) {
+    const t = tag as RuntimeComponent
+
+    if (!t.options) {
+      return t.name || Anonymous
+    } else {
+      return t.options.name || Anonymous
+    }
+  } else {
+    return Anonymous
+  }
+}
+
+const formatDataObject = (dataObject: VNodeData): string =>
+  [
+    ...formatDataObjectItem(dataObject.props),
+    ...formatDataObjectItem(dataObject.attrs),
+    ...formatDataObjectItem(dataObject.domProps, 'domProps'),
+    ...formatDataObjectItem(dataObject.on, 'on'),
+    ...formatDataObjectItem(dataObject.nativeOn, 'nativeOn'),
+    ...(dataObject.class ? [formatProp('class', dataObject.class)] : []),
+    ...(dataObject.style ? [formatProp('style', dataObject.style)] : []),
+    ...(dataObject.key ? [formatProp('key', dataObject.key)] : []),
+    ...(dataObject.ref ? [formatProp('ref', dataObject.ref)] : []),
+    ...(dataObject.slot ? [formatProp('slot', dataObject.slot)] : [])
+  ].join(' ')
+
+const formatDataObjectItem = (
+  item?: { [key: string]: any },
+  prefix: string = ''
+) =>
+  item
+    ? Object.keys(item).map(key =>
+        formatProp(
+          prefix ? prefix + key[0].toUpperCase() + key.slice(1) : key,
+          item[key]
+        )
+      )
+    : []
+
+const formatProp = (k: string, v: any): string =>
+  typeof v === 'string'
+    ? `${k}="${v}"`
+    : typeof v === 'function'
+      ? `${k}={${v.toString()}}`
+      : `${k}={${JSON.stringify(v)}}`

--- a/src/withInfo/index.ts
+++ b/src/withInfo/index.ts
@@ -17,6 +17,8 @@ import ComponentInfo from '../types/ComponentInfo'
 import getPropsInfoList from '../getPropsInfoList'
 import parseStoryComponent from '../parseStoryComponent'
 
+import getJSXFromRenderFn from '../utils/getJSXFromRenderFn'
+
 import InfoView from '../components/InfoView.vue'
 import lookupComponent from '../lookupComponent'
 
@@ -106,8 +108,7 @@ function withInfo(options: Partial<InfoAddonOptions> | string): WithInfo {
             storyTitle: context.story,
             summary: marked(dedent(opts.summary)),
             template: dedent(
-              story.template ||
-                '<!-- Sorry, story source for "render" is not supported. -->'
+              story.template || getJSXFromRenderFn(story.render! as any)
             ),
             componentDetails,
             showHeader: opts.header,

--- a/src/withInfo/index.ts
+++ b/src/withInfo/index.ts
@@ -110,6 +110,7 @@ function withInfo(options: Partial<InfoAddonOptions> | string): WithInfo {
             template: dedent(
               story.template || getJSXFromRenderFn(story.render! as any)
             ),
+            lang: story.template ? 'html' : 'jsx',
             componentDetails,
             showHeader: opts.header,
             showSource: opts.source,


### PR DESCRIPTION
# Summary

Add partial support for story that have `render` function instead of `template`.
Since [Vue.js is not supported custom renderer for now](https://github.com/vuejs/vue/issues/7005), this changes do hacks: call `render` function manually with custom `createElement` callback which returns JSX string.

See: #36 

# Limitations

* Accessing `this` in `render` throws an exception.

  ```js
  withInfo('summary', (() => ({
    data() {
      return { name: 'pocka' }
    },
    render(h) {
      return h('p', [`Hello, ${this.name}`]) // Error
    }
  })))
  ```
* All variables will be evaluated.

  ```jsx
  const foo = 3
  return <p>{foo}</p>
  ```

  will be

  ```jsx
  return <p>{3}</p>
  ```

* Functions will be inlined.

  ```jsx
  const myFunc = ev => console.log(ev)
  return <div onClick={myFunc}>foo</div>
  ```
  will be
  ```jsx
  ;<div onClick={function (ev) {console.log(ev);}}>foo</div>
  ```