### PR TITLE
Switch to vue-template-compiler for parsing template

### DIFF
--- a/example/stories/index.js
+++ b/example/stories/index.js
@@ -206,3 +206,13 @@ storiesOf('RenderFnComponent', module).add(
     }
   }))
 )
+
+storiesOf('Issues', module).add(
+  '#53',
+  withInfo({
+    summary: '<https://github.com/pocka/storybook-addon-vue-info/issues/53>'
+  })(() => ({
+    components: { NumberList },
+    template: '<NumberList :numbers="[1, 2]"/>'
+  }))
+)

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,12 +70,6 @@
       "integrity": "sha512-RisaZmcmCLjRipAY7nVi3fmkIk4Z0JMn8YHdGF6qYMsIDpD0dfzz+3yy2dL5Q5aHWOnqPx51IRxkA44myknJvw==",
       "dev": true
     },
-    "@types/parse5": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.0.tgz",
-      "integrity": "sha512-J5D3z703XTDIGQFYXsnU9uRCW9e9mMEFO0Kpe6kykyiboqziru/RlZ0hM2P+PKTG4NHG1SjLrqae/NrV2iJApQ==",
-      "dev": true
-    },
     "@types/storybook__vue": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@types/storybook__vue/-/storybook__vue-3.3.0.tgz",
@@ -2019,8 +2013,7 @@
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
-      "dev": true
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0="
     },
     "debug": {
       "version": "2.6.9",
@@ -3015,8 +3008,7 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "highlight.js": {
       "version": "9.12.0",
@@ -4757,11 +4749,6 @@
       "requires": {
         "error-ex": "1.3.1"
       }
-    },
-    "parse5": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.0.0.tgz",
-      "integrity": "sha512-0ywuiUOnpWWeil5grH2rxjyTJoeQVwyBuO2si6QIU9dWtj2npjuyK1HaY1RbLnVfDhEbhyAPNUBKRK0Xj2xE0w=="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -7297,7 +7284,6 @@
       "version": "2.5.16",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz",
       "integrity": "sha512-ZbuhCcF/hTYmldoUOVcu2fcbeSAZnfzwDskGduOrnjBiIWHgELAd+R8nAtX80aZkceWDKGQ6N9/0/EUpt+l22A==",
-      "dev": true,
       "requires": {
         "de-indent": "1.0.2",
         "he": "1.1.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/highlight.js": "^9.12.2",
     "@types/jest": "^22.2.3",
     "@types/marked": "^0.3.0",
-    "@types/parse5": "^5.0.0",
     "@types/storybook__vue": "^3.3.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-env": "^1.7.0",
@@ -55,8 +54,7 @@
     "tslint": "^5.10.0",
     "tslint-config-prettier": "^1.13.0",
     "typescript": "^2.9.2",
-    "vue": "^2.5.16",
-    "vue-template-compiler": "^2.5.16"
+    "vue": "^2.5.16"
   },
   "peerDependencies": {
     "vue": "^2.0.0",
@@ -83,6 +81,6 @@
     "dedent": "^0.7.0",
     "highlight.js": "^9.12.0",
     "marked": "^0.3.19",
-    "parse5": "^5.0.0"
+    "vue-template-compiler": "^2.5.16"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,5 +36,5 @@ export default {
       plugins: ['external-helpers']
     })
   ],
-  external: ['vue', 'dedent', 'marked', 'highlight.js']
+  external: ['vue', 'dedent', 'marked', 'highlight.js', 'vue-template-compiler']
 }

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -1,0 +1,19 @@
+declare module 'vue-template-compiler' {
+  export interface ASTElement {
+    attrs?: any[]
+    attrsList: any[]
+    attrsMap: { [key: string]: any }
+    children: ASTElement[]
+    parent?: ASTElement
+    plain: boolean
+    static: boolean
+    tag: string
+  }
+  export interface CompileResult {
+    ast?: ASTElement
+    render: string
+    staticRenderFns: string[]
+    errors: string[]
+  }
+  export function compile(template: string): CompileResult
+}

--- a/src/lib.d.ts
+++ b/src/lib.d.ts
@@ -7,7 +7,7 @@ declare module 'vue-template-compiler' {
     parent?: ASTElement
     plain: boolean
     static: boolean
-    tag: string
+    tag?: string
   }
   export interface CompileResult {
     ast?: ASTElement

--- a/src/utils/getTagNames.spec.ts
+++ b/src/utils/getTagNames.spec.ts
@@ -32,6 +32,10 @@ describe('#fromTemplate', () => {
     `)
     ).toEqual(['div', 'p'])
   })
+
+  it('Keeps case of tag names', () => {
+    expect(fromTemplate('<FooBar/>')).toEqual(['FooBar'])
+  })
 })
 
 describe('#fromJSX', () => {

--- a/src/utils/getTagNames.ts
+++ b/src/utils/getTagNames.ts
@@ -20,7 +20,7 @@ export const fromTemplate = (template: string): string[] => {
 const retrieveTagNamesFromAST = (el: ASTElement): string[] => {
   return [
     ...Array.from(el.children || []).map(e => retrieveTagNamesFromAST(e))
-  ].reduce((dest, cur) => [...dest, ...cur], [el.tag])
+  ].reduce((dest, cur) => [...dest, ...cur], el.tag ? [el.tag] : [])
 }
 
 type Render = (

--- a/src/utils/getTagNames.ts
+++ b/src/utils/getTagNames.ts
@@ -1,5 +1,5 @@
 import dedent from 'dedent'
-import { compile, ASTElement } from 'vue-template-compiler'
+import { ASTElement, compile } from 'vue-template-compiler'
 
 import removeDuplicates from './removeDuplicates'
 


### PR DESCRIPTION
Fix no props table appear when using CamelCase tag in template.
Since parse5 we used before turns all tags into lowercase, switched to [vue-template-compiler](https://github.com/vuejs/vue/tree/dev/packages/vue-template-compiler#readme) (Official template compiler).

Fix #53 