### PR TITLE
Remove color property from .vue-info(top level element)

### DIFF
--- a/src/components/InfoView.vue
+++ b/src/components/InfoView.vue
@@ -100,7 +100,6 @@ export default {
 <style scoped>
 .vue-info {
   padding: 0 1em;
-  color: #333;
 }
 
 .info-content {


### PR DESCRIPTION
Remove color property from `.vue-info` which is top level element (affects preview).

This PR fixes #55 .