### PR TITLE
Show class name if prop type is class

### DIFF
--- a/src/utils/constructorToString.spec.ts
+++ b/src/utils/constructorToString.spec.ts
@@ -28,10 +28,12 @@ it('Label of Function to equal "function"', () => {
   expect(constructorToString(Array)).toBe('array')
 })
 
-it('Other value will be "unknown"', () => {
-  expect(constructorToString(() => null)).toBe('unknown')
-
+it('Label of Class to equal its name', () => {
   function MyClass() {}
 
-  expect(constructorToString(MyClass)).toBe('unknown')
+  expect(constructorToString(MyClass)).toBe('MyClass')
+})
+
+it('Other value will be "unknown"', () => {
+  expect(constructorToString(() => null)).toBe('unknown')
 })

--- a/src/utils/constructorToString.ts
+++ b/src/utils/constructorToString.ts
@@ -24,7 +24,7 @@ const constructorToString = (
   } else if (constructor === Array) {
     return 'array'
   } else {
-    return 'unknown'
+    return constructor.name || 'unknown'
   }
 }
 


### PR DESCRIPTION
Hi, I'm using this plugin everyday.It's really convenient.
But I found that it shows "Type: unknown" when using with class prop.

```
  // Show Type: unknown in storybook
  @Prop({ type: SomeTypescriptClass, required: true }) someProp!: SomeTypescriptClass;
```

This PR fixed this problem.
Thanks.