### PR TITLE
[docs] update full control mode example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ And setup custom webpack loader in order to extract component information with [
 // .storybook/webpack.config.js
 
 // This example uses "Full control mode + default".
-// If you are using other mode, add payload of `defaultConfig.module.rules.push` to rules list.
-module.exports = (base, env, defaultConfig) => {
-  defaultConfig.module.rules.push({
+// If you are using other mode, add payload of `config.module.rules.push` to rules list.
+module.exports = ({ config }) => {
+  config.module.rules.push({
     test: /\.vue$/,
     loader: 'storybook-addon-vue-info/loader',
     enforce: 'post'
   })
 
-  return defaultConfig
+  return config
 }
 ```
 


### PR DESCRIPTION
Updated README for full control mode. 

Default configuration is located in first parameter that is object containing `config` and `mode` fields.

[Storybook full control mode](https://storybook.js.org/docs/configurations/custom-webpack-config/#full-control-mode)