### PR TITLE
Scoping highlight.js.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-vue": "^4.5.0",
     "jest": "^22.4.3",
+    "less": "^3.9.0",
     "prettier": "^1.12.1",
     "rollup": "^0.58.2",
     "rollup-plugin-babel": "^3.0.7",

--- a/src/components/StorySource/index.vue
+++ b/src/components/StorySource/index.vue
@@ -51,6 +51,4 @@ export default {
   </x-section-container>
 </template>
 
-<style src="../../../node_modules/highlight.js/styles/github.css" />
-
 <style module src="./style.css" />

--- a/src/components/StorySource/style.css
+++ b/src/components/StorySource/style.css
@@ -1,4 +1,4 @@
-.codeBlock {
+.codeBlock.codeBlock {
   margin: -8px;
   padding: 16px;
 
@@ -6,7 +6,7 @@
   background-color: #eee;
 }
 
-.codeBlock > code {
+.codeBlock.codeBlock > code {
   font-size: 12px;
 
   font-family: 'Roboto Mono', monospace;

--- a/src/components/Summary/index.vue
+++ b/src/components/Summary/index.vue
@@ -39,6 +39,4 @@ export default {
   <section v-else :class="$style.container" v-html="markdownHtml" />
 </template>
 
-<style src="../../../node_modules/highlight.js/styles/github.css" />
-
 <style module src="./style.css" />

--- a/src/components/Summary/style.css
+++ b/src/components/Summary/style.css
@@ -30,11 +30,11 @@
 }
 
 .container a {
-  color: #0D7CCD;
+  color: #0d7ccd;
 }
 
-.container pre,
-.container code {
+.container.container pre,
+.container.container code {
   font-size: 12px;
   padding: 4px 8px;
 
@@ -43,13 +43,13 @@
   border-radius: 4px;
 }
 
-.container pre {
+.container.container pre {
   display: block;
   padding: 16px;
   margin: 16px 0;
 }
 
-.container pre > code {
+.container.container pre > code {
   padding: 0;
   background-color: transparent;
   border-radius: 0;

--- a/src/components/Wrapper/index.vue
+++ b/src/components/Wrapper/index.vue
@@ -31,7 +31,7 @@ export default {
 </script>
 
 <template>
-  <x-docs>
+  <x-docs class="storybook-addon-vue-info">
     <x-header
       v-if="options.header"
       :title="info.title"
@@ -48,3 +48,9 @@ export default {
     <x-component v-for="c in info.components" :key="c.name" :component="c" />
   </x-docs>
 </template>
+
+<style lang="less">
+.storybook-addon-vue-info {
+  @import (less) '../../../node_modules/highlight.js/styles/github.css';
+}
+</style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,7 +4396,7 @@ entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-errno@^0.1.3, errno@~0.1.7:
+errno@^0.1.1, errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   integrity sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==
@@ -5704,6 +5704,11 @@ ignore@^3.3.3, ignore@^3.3.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
+image-size@~0.5.0:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
+  integrity sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=
+
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -6866,6 +6871,22 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
+less@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/less/-/less-3.9.0.tgz#b7511c43f37cf57dc87dffd9883ec121289b1474"
+  integrity sha512-31CmtPEZraNUtuUREYjSqRkeETFdyEHSEPAGq4erDlUXtda7pzNmctdljdIagSb589d/qXGWiiP31R5JVf+v0w==
+  dependencies:
+    clone "^2.1.2"
+  optionalDependencies:
+    errno "^0.1.1"
+    graceful-fs "^4.1.2"
+    image-size "~0.5.0"
+    mime "^1.4.1"
+    mkdirp "^0.5.0"
+    promise "^7.1.1"
+    request "^2.83.0"
+    source-map "~0.6.0"
+
 leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
@@ -7275,6 +7296,11 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.0.3, mime@^2.3.1:
   version "2.4.0"
@@ -9441,7 +9467,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@^2.87.0:
+request@^2.83.0, request@^2.87.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==


### PR DESCRIPTION
Fix #87 

Add namespace for imported CSS for highlight.js to prevent it from affecting other SB components.