### PR TITLE
Allow props with no "type" property

### DIFF
--- a/example/stories/issues/95/component.vue
+++ b/example/stories/issues/95/component.vue
@@ -1,0 +1,13 @@
+<script>
+export default {
+  props: {
+    foo: {
+      required: true
+    }
+  }
+}
+</script>
+
+<template>
+  <button>Hello, World!</button>
+</template>

--- a/example/stories/issues/95/index.stories.js
+++ b/example/stories/issues/95/index.stories.js
@@ -1,0 +1,29 @@
+import { storiesOf } from '@storybook/vue'
+
+import Issue95 from './component.vue'
+
+storiesOf('Issues/#95', module)
+  .add(
+    'Should not emit error for no-type props (with docgen)',
+    () => ({
+      components: { Issue95 },
+      template: '<issue-95/>'
+    }),
+    {
+      info: '<https://github.com/pocka/storybook-addon-vue-info/issues/95>'
+    }
+  )
+  .add(
+    'Should not emit error for no-type props (runtime)',
+    () => ({
+      components: { Issue95 },
+      template: '<issue-95/>'
+    }),
+    {
+      info: {
+        summary:
+          '<https://github.com/pocka/storybook-addon-vue-info/issues/95>',
+        useDocgen: false
+      }
+    }
+  )

--- a/src/extract/extractDocgenInfo.ts
+++ b/src/extract/extractDocgenInfo.ts
@@ -12,7 +12,7 @@ export function extractDocgenInfo(component: AnyComponent): Extracted {
 
         return {
           name,
-          type: prop.type.name,
+          type: prop.type ? prop.type.name : 'any',
           required: !!prop.required,
           default: prop.defaultValue ? prop.defaultValue.value : undefined,
           description: prop.description

--- a/src/extract/getProps.ts
+++ b/src/extract/getProps.ts
@@ -57,7 +57,7 @@ export function getProps(component: AnyComponent): PropInfo[] {
 
     return {
       name,
-      type: constructorToString(propDef.type),
+      type: propDef.type ? constructorToString(propDef.type) : 'any',
       required: propDef.required,
       default: default$
     }


### PR DESCRIPTION
Do not emit an error for props not having `type` field.

Fix #95 

[Preview](https://deploy-preview-97--storybook-addon-vue-info.netlify.com/?path=/story/issues-95--should-not-emit-error-for-no-type-props-with-docgen)