### PR TITLE
Add options to customize preview container style

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ For more details, see [live examples].
 | `header`           | `boolean`                             | `true`                                              | Whether to show header or not.                                                     |
 | `source`           | `boolean`                             | `true`                                              | Whether to show source(usage) or not.                                              |
 | `wrapperComponent` | `Component`                           | [default wrapper](src/components/Wrapper/index.vue) | Override inline docs component.                                                    |
+| `previewClassName` | `string`                              | `undefined`                                         | Class name passed down to preview container.                                       |
+| `previewStyle`     | Style object                          | `undefined`                                         | Style passed down to preview container.                                            |
 | `summary`          | `string`                              | `''`                                                | Summary for the story. Accepts Markdown.                                           |
 | `components`       | `{ [name: string]: Component }\|null` | `null`                                              | Display info for these components. Same type as component's `components` property. |
 | `docsInPanel`      | `boolean`                             | `true`                                              | Whether to show docs in addon panel.                                               |

--- a/example/stories/examples/index.stories.js
+++ b/example/stories/examples/index.stories.js
@@ -233,6 +233,27 @@ storiesOf('Examples/Advance usage', module)
     }
   )
   .add(
+    'Apply custom styles to preview',
+    () => ({
+      components: { BaseButton },
+      template: '<base-button label="I\'m a button!"/>'
+    }),
+    {
+      info: {
+        docsInPanel: false,
+        previewClassName: 'my-custom-class-name',
+        previewStyle: {
+          backgroundColor: 'tomato',
+          padding: '1em'
+        },
+        summary: `
+        You can customize preview wrapper style by
+        passing \`previewClassName\` option or \`previewStyle\` option.
+      `
+      }
+    }
+  )
+  .add(
     'Customize docs',
     () => ({
       components: { BaseButton },

--- a/src/components/Preview/index.vue
+++ b/src/components/Preview/index.vue
@@ -2,17 +2,19 @@
 import XSectionContainer from '../SectionContainer/index.vue'
 
 export default {
+  components: { XSectionContainer },
   props: {
     customClassName: {
       type: String,
-      required: false
+      required: false,
+      default: undefined
     },
     customStyle: {
       type: Object,
-      required: false
+      required: false,
+      default: undefined
     }
-  },
-  components: { XSectionContainer }
+  }
 }
 </script>
 

--- a/src/components/Preview/index.vue
+++ b/src/components/Preview/index.vue
@@ -2,13 +2,25 @@
 import XSectionContainer from '../SectionContainer/index.vue'
 
 export default {
+  props: {
+    customClassName: {
+      type: String,
+      required: false
+    },
+    customStyle: {
+      type: Object,
+      required: false
+    }
+  },
   components: { XSectionContainer }
 }
 </script>
 
 <template>
   <x-section-container label="Preview">
-    <div :class="$style.preview"><slot /></div>
+    <div :class="[$style.preview, customClassName]" :style="customStyle">
+      <slot />
+    </div>
   </x-section-container>
 </template>
 

--- a/src/components/Wrapper/index.vue
+++ b/src/components/Wrapper/index.vue
@@ -37,7 +37,13 @@ export default {
       :title="info.title"
       :subtitle="info.subtitle"
     />
-    <x-preview v-if="!options.docsInPanel"> <slot /> </x-preview>
+    <x-preview
+      v-if="!options.docsInPanel"
+      :customClassName="options.previewClassName"
+      :customStyle="options.previewStyle"
+    >
+      <slot />
+    </x-preview>
     <x-summary :markdown="info.summary" />
     <x-story-source
       v-if="options.source"

--- a/src/components/Wrapper/index.vue
+++ b/src/components/Wrapper/index.vue
@@ -39,8 +39,8 @@ export default {
     />
     <x-preview
       v-if="!options.docsInPanel"
-      :customClassName="options.previewClassName"
-      :customStyle="options.previewStyle"
+      :custom-class-name="options.previewClassName"
+      :custom-style="options.previewStyle"
     >
       <slot />
     </x-preview>

--- a/src/options.ts
+++ b/src/options.ts
@@ -31,6 +31,9 @@ export interface InfoAddonOptions {
    */
   summary: string
 
+  previewClassName?: string
+  previewStyle?: ElementCSSInlineStyle
+
   /**
    * Explicitly specify components to display info
    */


### PR DESCRIPTION
Add `previewClassName` option and `previewStyle` option to allow users to customize style of a preview container.

Close  #93 

[Preview](https://deploy-preview-98--storybook-addon-vue-info.netlify.com/?path=/story/examples-advance-usage--apply-custom-styles-to-preview)