### PR TITLE
style: Fix stick out from small display

### DIFF
--- a/src/components/Table/index.vue
+++ b/src/components/Table/index.vue
@@ -12,9 +12,11 @@ export default {
 <template>
   <div :class="$style.container">
     <label v-if="label" :class="$style.label">{{ label }}</label>
-    <table :class="$style.table">
-      <slot />
-    </table>
+    <div :class="$style.contents">
+      <table :class="$style.table">
+        <slot />
+      </table>
+    </div>
   </div>
 </template>
 

--- a/src/components/Table/style.css
+++ b/src/components/Table/style.css
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .label {
@@ -10,14 +11,17 @@
   margin-bottom: 8px;
 }
 
+.contents {
+  overflow: auto;
+  border: 1px solid #333;
+  border-radius: 4px;
+}
+
 .table {
   position: relative;
   font-size: 12px;
   width: 100%;
   border-spacing: 0;
-
-  border: 1px solid #333;
-  border-radius: 4px;
 }
 
 .table thead {


### PR DESCRIPTION
Hi, I'm ken.

I found stick out from Screen width 320px device(iPod Touch) in inline view.

I fixed it, like a Preview and Story source feature view.

before | after
--|--
<img width="320" alt="スクリーンショット 2019-06-05 19 30 59" src="https://user-images.githubusercontent.com/6585191/58949929-8ff64080-87c8-11e9-88f2-73289b4b66ff.png">|<img width="320" alt="スクリーンショット 2019-06-05 19 31 10" src="https://user-images.githubusercontent.com/6585191/58949930-8ff64080-87c8-11e9-956d-aa153b770019.png">


[Preview](https://nifty-kirch-bee875.netlify.com/)

Thanks for reading:)