### PR TITLE
get default value only if prop is specified as an object

### DIFF
--- a/src/extract/getProps.ts
+++ b/src/extract/getProps.ts
@@ -52,7 +52,7 @@ export function getProps(component: AnyComponent): PropInfo[] {
         default$ = 'Failed to get default value'
       }
     } else {
-      default$ = 'default' in propDef ? JSON.stringify(propDef.default) : ''
+      default$ = typeof propDef === 'object' && 'default' in propDef ? JSON.stringify(propDef.default) : ''
     }
 
     return {

--- a/src/extract/getProps.ts
+++ b/src/extract/getProps.ts
@@ -52,7 +52,10 @@ export function getProps(component: AnyComponent): PropInfo[] {
         default$ = 'Failed to get default value'
       }
     } else {
-      default$ = typeof propDef === 'object' && 'default' in propDef ? JSON.stringify(propDef.default) : ''
+      default$ =
+        typeof propDef === 'object' && 'default' in propDef
+          ? JSON.stringify(propDef.default)
+          : ''
     }
 
     return {


### PR DESCRIPTION
When props is specified as an array of strings this line throws an error because it uses the `in` operator on a string. Adding an additional condition can prevent this error.

Refer to this issue for more details #107 