### PR TITLE
Use deepest <story> component to support extra wrappers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,27 @@ import { renderToPanel } from './view'
 
 export * from './components'
 
+function findBottomStorybookWraps(w: any) {
+  while (
+    w &&
+    w.options &&
+    w.options.components &&
+    w.options.components.story &&
+    w.options.components.story.options &&
+    w.options.components.story.options.STORYBOOK_WRAPS
+  ) {
+    w = w.options.components.story.options.STORYBOOK_WRAPS
+  }
+  return w
+}
+
+function getComponentOptions(story: any) {
+  if (story.fnOptions && story.fnOptions.STORYBOOK_WRAPS) {
+    return findBottomStorybookWraps(story.fnOptions.STORYBOOK_WRAPS).options
+  }
+  return ((story.componentOptions && story.componentOptions.Ctor) || {}).options
+}
+
 export const withInfo = makeDecorator({
   name: 'withInfo',
   parameterName: 'info',
@@ -26,13 +47,7 @@ export const withInfo = makeDecorator({
     return Vue.extend({
       render(h) {
         const story = h(getStory(context)) as any
-
-        const { options: componentOptions } = (story.fnOptions &&
-          story.fnOptions.STORYBOOK_WRAPS) ||
-          (story.componentOptions && story.componentOptions.Ctor) || {
-            options: undefined
-          }
-
+        const componentOptions = getComponentOptions(story)
         const info = extract(
           componentOptions,
           context.kind,

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,6 @@ export const withInfo = makeDecorator({
         : parameters)
     }
 
-    const WrappedComponent = getStory(context)
-
     return Vue.extend({
       render(h) {
         const story = h(getStory(context)) as any


### PR DESCRIPTION
I'm using vuetify and it requires `<v-app>` as the most outer component so that I use the following decorator to add it

```typescript
addDecorator(() => ({
  template: '<v-app><story /></v-app>',
}));
```

But with the decorator, storybook-addon-vue-info failed to detect the correct component for story like

```typescript
storiesOf('KBalloonTip', module).add(
  'Without arguments',
  () => ({
    components: { KBalloonTip },
    template: '<k-balloon-tip bottom><span>Hello World</span></k-balloon-tip>',
  }),
  {
    info: true,
  },
);
```

and it produces an info panel like below

<img width="821" alt="Storybook 2019-09-03 02-02-04" src="https://user-images.githubusercontent.com/546312/64128029-48934680-cdef-11e9-932b-c9d1ffaa4049.png">


With this PR, it produces an info panel like

<img width="836" alt="Storybook 2019-09-03 01-59-04" src="https://user-images.githubusercontent.com/546312/64128048-6a8cc900-cdef-11e9-94f4-1339965d79f4.png">
