### PR TITLE
Deprecate custom loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ Then register in `addons.js`.
 import 'storybook-addon-vue-info/lib/register'
 ```
 
-And setup custom webpack loader in order to extract component information with [vue-docgen-api](https://github.com/vue-styleguidist/vue-docgen-api).
+And setup a webpack loader in order to extract component information with [vue-docgen-api](https://github.com/vue-styleguidist/vue-docgen-api).
+
+```sh
+npm install --save-dev vue-docgen-loader vue-docgen-api
+
+# yarn add -D vue-docgen-loader vue-docgen-api
+```
 
 ```js
 // .storybook/webpack.config.js
@@ -59,7 +65,7 @@ And setup custom webpack loader in order to extract component information with [
 module.exports = ({ config }) => {
   config.module.rules.push({
     test: /\.vue$/,
-    loader: 'storybook-addon-vue-info/loader',
+    loader: 'vue-docgen-loader',
     enforce: 'post'
   })
 
@@ -172,29 +178,6 @@ storiesOf('MyComponent', module)
 ```
 
 For more detail, please take a look at [live example](https://storybook-addon-vue-info.netlify.com/?path=/story/examples-advance-usage--set-descriptions-manually).
-
-### Loader options
-
-You can pass options for vue-docgen-api through loader options (e.g. module alias).
-
-```js
-// .storybook/webpack.config.js
-
-module.exports = ({ config }) => {
-  config.module.rules.push({
-    test: /\.vue$/,
-    loader: 'storybook-addon-vue-info/loader',
-    options: {
-      docgenOptions: {
-        // options for vue-docgen-api...
-      }
-    },
-    enforce: 'post'
-  })
-
-  return config
-}
-```
 
 ## Example
 

--- a/example/.storybook/webpack.config.js
+++ b/example/.storybook/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = ({ config }) => {
 
   config.module.rules.push({
     test: /\.vue$/,
-    loader: 'storybook-addon-vue-info/loader',
+    loader: 'vue-docgen-loader',
     options: {
       docgenOptions: {
         alias: config.resolve.alias

--- a/example/package.json
+++ b/example/package.json
@@ -37,6 +37,8 @@
     "babel-preset-vue": "^2.0.2",
     "highlight.js": "^9.14.1",
     "marked": "^0.6.0",
+    "vue-docgen-api": "^3.26.0",
+    "vue-docgen-loader": "^1.0.0",
     "vue-i18n": "^8.8.0",
     "vue-loader": "^15.6.1",
     "vue-template-compiler": "^2.5.22",

--- a/loader/index.js
+++ b/loader/index.js
@@ -3,6 +3,10 @@ const docgen = require('vue-docgen-api')
 const loaderUtils = require('loader-utils')
 const qs = require('querystring')
 
+console.warn(
+  'storybook-addon-vue-info/loader is deprecated. Please consider using vue-docgen-loader instead.'
+)
+
 module.exports = function(content, map) {
   const queries = qs.parse(this.resourceQuery.slice(1))
 


### PR DESCRIPTION
Use vue-docgen-loader instead.

@storybook/addon-docs depends on this package because of the loader,
but it's not clean: users need to install unnecessary dependencies.
In order to solve this, I moved the loader out as vue-docgen-loader and
deprecate the custom loader.

related: #65 