### PR TITLE
Stringify function default value

### DIFF
--- a/example/stories/issues/126/component.vue
+++ b/example/stories/issues/126/component.vue
@@ -1,0 +1,17 @@
+<script>
+export default {
+  props: {
+    /**
+     * Should show the default value
+     */
+    foo: {
+      type: Function,
+      default: obj => obj.bar
+    }
+  }
+}
+</script>
+
+<template>
+  <button>Button</button>
+</template>

--- a/example/stories/issues/126/index.stories.js
+++ b/example/stories/issues/126/index.stories.js
@@ -1,0 +1,21 @@
+import Issue126 from './component.vue'
+
+export default {
+  title: 'Issues/#126'
+}
+
+export const showDefaultValue = () => {
+  return {
+    components: { Issue126 },
+    template: '<issue-126/>'
+  }
+}
+
+showDefaultValue.story = {
+  title: 'Show default value without docgen',
+  parameters: {
+    info: {
+      useDocgen: false
+    }
+  }
+}

--- a/src/extract/getProps.ts
+++ b/src/extract/getProps.ts
@@ -41,7 +41,9 @@ export function getProps(component: AnyComponent): PropInfo[] {
 
     let default$
 
-    if (typeof propDef.default === 'function') {
+    if (propDef.type === Function && propDef.default) {
+      default$ = propDef.default.toString()
+    } else if (typeof propDef.default === 'function') {
       try {
         default$ = JSON.stringify(propDef.default.apply(component))
       } catch (e) {


### PR DESCRIPTION
Call `[function].toString()` for the default values for Function props.

Fix #126 